### PR TITLE
Windows Continous Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Open a terminal in the root of the project directory, then execute the command:
 WINDOWS INTEGRATION PROCESS
 Ngrok server installed.
 Jenkins integration installed.
-Windows Integration added at Jenkins.
+Windows Integration added at Jenkins

--- a/README.md
+++ b/README.md
@@ -64,5 +64,3 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
-
-w ci add

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
-aaa
+aa

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-
-
 <p align="center">
   <a title="Build Status" href="https://travis-ci.org/kasirgalabs/ETUmulator"><img src="https://travis-ci.org/kasirgalabs/ETUmulator.svg?branch=master"></a>
-  <a title="Windows Build Status:" href='http://0612aae3.ngrok.io/job/ETUmulator'><img src='http://0612aae3.ngrok.io/job/ETUmulator/badge/icon'></a>
+  <a title=Windows Build Status:" href='http://0612aae3.ngrok.io/job/ETUmulator'><img src='http://0612aae3.ngrok.io/buildStatus/icon?job=ETUmulator'></a>
   <a title="Coverage" href="https://www.codacy.com/app/RootG/ETUmulator?utm_source=github.com&utm_medium=referral&utm_content=kasirgalabs/ETUmulator&utm_campaign=Badge_Coverage"><img src="https://api.codacy.com/project/badge/Coverage/b79a64268c3b4ab38699a5780e773302"></a>
   <a title="Grade" href="https://www.codacy.com/app/RootG/ETUmulator?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=kasirgalabs/ETUmulator&amp;utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/b79a64268c3b4ab38699a5780e773302"></a>
   <a title="Dependency Status" href="https://www.versioneye.com/user/projects/58b1886d7b9e15004de85395"><img src="https://www.versioneye.com/user/projects/58b1886d7b9e15004de85395/badge.svg?style=flat-square"></a>
@@ -67,3 +65,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+
+
 <p align="center">
   <a title="Build Status" href="https://travis-ci.org/kasirgalabs/ETUmulator"><img src="https://travis-ci.org/kasirgalabs/ETUmulator.svg?branch=master"></a>
+  <a title="Windows Build Status:" href='http://0612aae3.ngrok.io/job/ETUmulator'><img src='http://0612aae3.ngrok.io/job/ETUmulator/badge/icon'></a>
   <a title="Coverage" href="https://www.codacy.com/app/RootG/ETUmulator?utm_source=github.com&utm_medium=referral&utm_content=kasirgalabs/ETUmulator&utm_campaign=Badge_Coverage"><img src="https://api.codacy.com/project/badge/Coverage/b79a64268c3b4ab38699a5780e773302"></a>
   <a title="Grade" href="https://www.codacy.com/app/RootG/ETUmulator?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=kasirgalabs/ETUmulator&amp;utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/b79a64268c3b4ab38699a5780e773302"></a>
   <a title="Dependency Status" href="https://www.versioneye.com/user/projects/58b1886d7b9e15004de85395"><img src="https://www.versioneye.com/user/projects/58b1886d7b9e15004de85395/badge.svg?style=flat-square"></a>

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
-Added windows integration
+

--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
+aaa

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ WINDOWS INTEGRATION PROCESS
 Ngrok server installed.
 Jenkins integration installed.
 Windows Integration added at Jenkins
-
+.

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ WINDOWS INTEGRATION PROCESS
 Ngrok server installed.
 Jenkins integration installed.
 Windows Integration added at Jenkins
-aaa
+

--- a/README.md
+++ b/README.md
@@ -64,8 +64,3 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
-WINDOWS INTEGRATION PROCESS
-Ngrok server installed.
-Jenkins integration installed.
-Windows Integration added at Jenkins
-.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ WINDOWS INTEGRATION PROCESS
 Ngrok server installed.
 Jenkins integration installed.
 Windows Integration added at Jenkins
+aaa

--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
+Added windows integration

--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ./gradlew check
 ```
 
+w ci add

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
-aa
+Windows Integration added at Jenkins.

--- a/README.md
+++ b/README.md
@@ -64,4 +64,7 @@ Open a terminal in the root of the project directory, then execute the command:
 ```
 ./gradlew check
 ```
+WINDOWS INTEGRATION PROCESS
+Ngrok server installed.
+Jenkins integration installed.
 Windows Integration added at Jenkins.

--- a/WindowsIntegration
+++ b/WindowsIntegration
@@ -1,0 +1,13 @@
+Windows integration added on jenkins
+
+link:http://18ce9130.ngrok.io/
+
+
+
+
+-tools used-
+https://ngrok.com/
+https://jenkins.io/
+https://wiki.jenkins.io/display/JENKINS/GitHub+Plugin
+https://wiki.jenkins.io/display/JENKINS/Git+Plugin
+https://wiki.jenkins.io/display/JENKINS/Gradle+Plugin

--- a/WindowsIntegration
+++ b/WindowsIntegration
@@ -1,13 +1,30 @@
-Windows integration added on jenkins
+Windows integration added.
 
-link:http://18ce9130.ngrok.io/
+Used jenkins for ci integration.
+
+General Information about jenkins:http://www.wiki-zero.com/index.php?q=aHR0cHM6Ly9lbi53aWtpcGVkaWEub3JnL3dpa2kvSmVua2luc18oc29mdHdhcmUp
+User Manual:https://wiki.jenkins.io/display/JENKINS/Use+Jenkins
+
+Process
+-installed jenkins server on windows.
+-used ngrok for exposing a web server for a  running  local machine to the internet. 
+-configured jenkins for ETUmulator project.
+-Plugins added(many of them are optional,added for better information).
+-injected graddle wrapper and git,github build.
+-webhook added for build automation.
 
 
+
+
+
+link:http://0612aae3.ngrok.io/
 
 
 -tools used-
-https://ngrok.com/
+https://ngrok.com/ 
 https://jenkins.io/
+https://wiki.jenkins.io/display/JENKINS/Embeddable+Build+Status+Plugin
 https://wiki.jenkins.io/display/JENKINS/GitHub+Plugin
 https://wiki.jenkins.io/display/JENKINS/Git+Plugin
 https://wiki.jenkins.io/display/JENKINS/Gradle+Plugin
+https://wiki.jenkins.io/display/JENKINS/Disk+Usage+Plugin

--- a/WindowsIntegration
+++ b/WindowsIntegration
@@ -5,26 +5,7 @@ Used jenkins for ci integration.
 General Information about jenkins:http://www.wiki-zero.com/index.php?q=aHR0cHM6Ly9lbi53aWtpcGVkaWEub3JnL3dpa2kvSmVua2luc18oc29mdHdhcmUp
 User Manual:https://wiki.jenkins.io/display/JENKINS/Use+Jenkins
 
-Process
--installed jenkins server on windows.
--used ngrok for exposing a web server for a  running  local machine to the internet. 
--configured jenkins for ETUmulator project.
--Plugins added(many of them are optional,added for better information).
--injected graddle wrapper and git,github build.
--webhook added for build automation.
-
-
-
-
-
 link:http://0612aae3.ngrok.io/
 
 
--tools used-
-https://ngrok.com/ 
-https://jenkins.io/
-https://wiki.jenkins.io/display/JENKINS/Embeddable+Build+Status+Plugin
-https://wiki.jenkins.io/display/JENKINS/GitHub+Plugin
-https://wiki.jenkins.io/display/JENKINS/Git+Plugin
-https://wiki.jenkins.io/display/JENKINS/Gradle+Plugin
-https://wiki.jenkins.io/display/JENKINS/Disk+Usage+Plugin
+


### PR DESCRIPTION
As you wish Windows integration added with different ci tool than appveyor.Used jenkins for ci integration.

General Information about jenkins:http://www.wiki-zero.com/index.php?q=aHR0cHM6Ly9lbi53aWtpcGVkaWEub3JnL3dpa2kvSmVua2luc18oc29mdHdhcmUp
User Manual:https://wiki.jenkins.io/display/JENKINS/Use+Jenkins

Process
-installed jenkins server on windows.
-installed and used ngrok for exposing a web server for a  running  local machine to the internet. 
-configured jenkins for ETUmulator project.
-Plugins added(many of them are optional,added for better information).
-injected graddle wrapper for build.
-Git and github integrations added for ETUmulator.
-Webhook added for build automation.
-Security configurations setted.
-Github Token set.
-Windows Build status badge created and added to ReadMe file.




link:http://0612aae3.ngrok.io/


-tools used-
https://ngrok.com/ 
https://jenkins.io/
https://wiki.jenkins.io/display/JENKINS/Embeddable+Build+Status+Plugin
https://wiki.jenkins.io/display/JENKINS/GitHub+Plugin
https://wiki.jenkins.io/display/JENKINS/Git+Plugin
https://wiki.jenkins.io/display/JENKINS/Gradle+Plugin
https://wiki.jenkins.io/display/JENKINS/Disk+Usage+Plugin